### PR TITLE
fix: update Terraform required version to 1.3

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -9,5 +9,5 @@ terraform {
       version = "3.7.1"
     }
   }
-  required_version = ">= 1.1.9"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Changes the required version of Terraform from ">= 1.1.9" to 
">= 1.3" in the providers.tf file to ensure compatibility 
with the latest features and improvements.